### PR TITLE
nip-01: allow prefix search of id, author in request filter.

### DIFF
--- a/nips/01.md
+++ b/nips/01.md
@@ -55,25 +55,27 @@ Clients can send 3 types of messages, which must be JSON arrays, according to th
   * `["REQ", <id>, <filter JSON>...`], used to request events and subscribe to new updates.
   * `["CLOSE", <id>]`, used to stop previous subscriptions.
 
-`<id>` is a random string that should be used to represent a subscription. The same
+`<id>` is a random string that should be used to represent a subscription.
 
 `<filters>` is a JSON object that determines what events will be sent in that subscription, it can have the following attributes:
 
 ```
 {
-  "ids": <a list of event ids>,
+  "ids": <a list of event ids or prefixes>,
   "kinds": <a list of a kind numbers>,
   "#e": <a list of event ids that are referenced in an "e" tag>,
   "#p": <a list of pubkeys that are referenced in a "p" tag>,
   "since": <a timestamp, events must be newer than this to pass>,
   "until": <a timestamp, events must be older than this to pass>,
-  "authors": <a list of pubkeys, the pubkey of an event must be one of these>
+  "authors": <a list of pubkeys or prefixes, the pubkey of an event must be one of these>
 }
 ```
 
 Upon receiving a `REQ` message, the relay MUST query its internal database and return events that match the filter, then store that filter and send again all future events it receives to that same websocket until the websocket is closed, the `CLOSE` event is received with the same `<id>` or a new `REQ` is sent using the same id, in which case it should overwrite the previous subscription.
 
 Filter attributes containing lists (such as `ids`, `kinds`, or `#e`) are JSON arrays with one or more values.  At least one of the array's values must match the relevant field in an event for the condition itself to be considered a match.  For scalar event attributes such as `kind`, the attribute from the event must be contained in the filter list.  For tag attributes such as `#e`, where an event may have multiple values, the event and filter condition values must have at least one item in common.
+
+The `ids` and `authors` lists contain lowercase hexadecimal strings, which may either be an exact 64-character match, or a prefix of the event value.  A prefix match is when the filter string is an exact string prefix of the event value.  The use of prefixes allows for more compact filters where a large number of values are queried, and can provide some privacy for clients that may not want to disclose the exact authors or events they are searching for.
 
 All conditions of a filter that are specified must match for an event for it to pass the filter, i.e., multiple conditions are interpreted as `&&` conditions.
 


### PR DESCRIPTION
This defines the `ids` and `authors` request filter fields as allowing exact match as well as prefixes of the `id` and `author` event fields.

Fixes #60 