### PR TITLE
NIP-01: Add `status` to event kind 0

### DIFF
--- a/nips/01.md
+++ b/nips/01.md
@@ -94,7 +94,7 @@ This NIP defines no rules for how `NOTICE` messages should be sent or treated.
 
 ## Basic Event Kinds
 
-  - `0`: `set_metadata`: the `content` is set to a stringified JSON object `{name: <string>, about: <string>, picture: <url, string>}` describing the user who created the event. A relay may delete past `set_metadata` events once it gets a new one for the same pubkey.
+  - `0`: `set_metadata`: the `content` is set to a stringified JSON object `{name: <string>, about: <string>, picture: <url, string>, status: <string>}` describing the user who created the event. A relay may delete past `set_metadata` events once it gets a new one for the same pubkey.
   - `1`: `text_note`: the `content` is set to the text content of a note (anything the user wants to say).
   - `2`: `recommend_server`: the `content` is set to the URL (e.g., `https://somerelay.com`) of a relay the event creator wants to recommend to its followers.
 


### PR DESCRIPTION
Add `status` to `set_metadata`. Clients can send this field to specify what the owner of `pubkey` is currently doing.