### PR TITLE
"Notes and Stuff by Relays" update to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Nostr - Notes and Other Stuff Transmitted by Relays
+# Nostr - Notes and Stuff on Relays
 
 The simplest open protocol that is able to create a censorship-resistant global "social" network once and for all.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Nostr - Notes and Stuff on Relays
+# Nostr - Notes and Stuff over Relays
 
 The simplest open protocol that is able to create a censorship-resistant global "social" network once and for all.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Nostr - Notes and Stuff over Relays
+# Nostr - Notes and Stuff by Relays
 
 The simplest open protocol that is able to create a censorship-resistant global "social" network once and for all.
 


### PR DESCRIPTION
Likely to go unnoticed, this change is to aid branding. It is consistent with the long standing descriptor of the purpose and makeup of the protocol. If this change is noticed, it's likely to be appreciated, because it can help more clearly and succinctly convey what the protocol is. 

The abbreviation still works NOSTR is made up of the following capitals: "NOtes and STuff on Relays". Still in sequence and with appropriate emphasis and meaning. 

So, we still call it Nostr. We still know it's abbreviated. We still know it's a protocol with notes and stuff and relays. And we still know it's what we've always used. It's just now easier to tie to a tagline that is just as descriptive without such a long sentence. This will be helpful for newly onboarded users and for when referenced in content and media. 

I'll just leave this pull request here for you. Enjoy. 

(I created this once before, but fiatjaf said thanks but no thanks so I deleted it. But, I'm throwing this back out there and will leave it because I think there's merit.)